### PR TITLE
Add more extension methods for throwing exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ In some cases, throwing an exception on failed statuses is the desired behaviour
 
 ```csharp
 var failedResult = IDomainResult.Failed("Ahh!");
-failedResult.ThrowIfNoSuccess();    // DomainResultException is thrown here 
+failedResult.ThrowIfNoSuccess();                    // DomainResultException is thrown here 
+failedResult.ThrowIfNoSuccess<CustomException>();   // CustomException is thrown here 
 ```
 
 ## 'DomainResult' package

--- a/src/Common/Exceptions/DomainResultThrowCustomExceptionExtensions.cs
+++ b/src/Common/Exceptions/DomainResultThrowCustomExceptionExtensions.cs
@@ -18,12 +18,12 @@ namespace DomainResults.Common.Exceptions
 		{
 			if (domainResult.IsSuccess) 
 				return;
-			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			try { throw (TE)Activator.CreateInstance(typeof(TE), ConcatenateErrors(domainResult, errMsg)); }
 			catch (MissingMethodException) { throw new TE(); }
 		}
 		
 		///  <summary>
-		/// 		Throw <typeparamref name="TE"/> if <paramref name="domainResult"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// 	Throw <typeparamref name="TE"/> if <paramref name="domainResult"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
 		///  </summary>
 		///  <param name="domainResult"> The IDomainResult to check </param>
 		///  <param name="errMsg"> The error message </param>
@@ -34,7 +34,7 @@ namespace DomainResults.Common.Exceptions
 		{
 			if (domainResult.IsSuccess)
 				return domainResult.Value;
-			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			try { throw (TE)Activator.CreateInstance(typeof(TE), ConcatenateErrors(domainResult, errMsg)); }
 			catch (MissingMethodException) { throw new TE(); }
 		}
 		/// <summary>
@@ -50,7 +50,7 @@ namespace DomainResults.Common.Exceptions
 			var (result, status) = domainResult;
 			if (status.IsSuccess)
 				return result;
-			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			try { throw (TE)Activator.CreateInstance(typeof(TE), ConcatenateErrors(status, errMsg)); }
 			catch (MissingMethodException) { throw new TE(); }
 		}
 		
@@ -66,7 +66,7 @@ namespace DomainResults.Common.Exceptions
 			var domainResult = await domainResultTask.ConfigureAwait(true);
 			if (domainResult.IsSuccess)
 				return;
-			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			try { throw (TE)Activator.CreateInstance(typeof(TE), ConcatenateErrors(domainResult, errMsg)); }
 			catch (MissingMethodException) { throw new TE(); }
 		}
 		/// <summary>
@@ -82,7 +82,7 @@ namespace DomainResults.Common.Exceptions
 			var domainResult = await domainResultTask.ConfigureAwait(true);
 			if (domainResult.IsSuccess)
 				return domainResult.Value;
-			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			try { throw (TE)Activator.CreateInstance(typeof(TE), ConcatenateErrors(domainResult, errMsg)); }
 			catch (MissingMethodException) { throw new TE(); }
 		}
 		/// <summary>
@@ -98,8 +98,11 @@ namespace DomainResults.Common.Exceptions
 			var (result, status) = await domainResultTask.ConfigureAwait(true);
 			if (status.IsSuccess)
 				return result;
-			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			try { throw (TE)Activator.CreateInstance(typeof(TE), ConcatenateErrors(status, errMsg)); }
 			catch (MissingMethodException) { throw new TE(); }
 		}
+		
+		private static string ConcatenateErrors(IDomainResultBase result, string? baseErrMsg = null)
+			=> result.Error + (!string.IsNullOrWhiteSpace(baseErrMsg) ? ". "+baseErrMsg : "");
 	}
 }

--- a/src/Common/Exceptions/DomainResultThrowCustomExceptionExtensions.cs
+++ b/src/Common/Exceptions/DomainResultThrowCustomExceptionExtensions.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace DomainResults.Common.Exceptions
+{
+	/// <summary>
+	///     Extension methods to throw custom exceptions if <see cref="DomainResult.IsSuccess"/> is <value>false</value>.
+	/// </summary>
+	public static class DomainResultThrowCustomExceptionExtensions
+	{
+		/// <summary>
+		///		Throw <typeparamref name="TE"/> if <paramref name="domainResult"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// </summary>
+		/// <param name="domainResult"> The IDomainResult to check </param>
+		/// <param name="errMsg"> The error message </param>
+		/// <typeparam name="TE">The exception type to throw if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </typeparam>
+		public static void ThrowIfNoSuccess<TE>(this IDomainResult domainResult, string? errMsg = null) where TE: Exception, new()
+		{
+			if (domainResult.IsSuccess) 
+				return;
+			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			catch (MissingMethodException) { throw new TE(); }
+		}
+		
+		///  <summary>
+		/// 		Throw <typeparamref name="TE"/> if <paramref name="domainResult"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		///  </summary>
+		///  <param name="domainResult"> The IDomainResult to check </param>
+		///  <param name="errMsg"> The error message </param>
+		///  <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
+		///  <typeparam name="TE">The exception type to throw if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </typeparam>
+		///  <typeparam name="T"> The value type of successful <paramref name="domainResult"/> </typeparam>
+		public static T ThrowIfNoSuccess<T, TE>(this IDomainResult<T> domainResult, string? errMsg = null) where TE: Exception, new()
+		{
+			if (domainResult.IsSuccess)
+				return domainResult.Value;
+			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			catch (MissingMethodException) { throw new TE(); }
+		}
+		/// <summary>
+		/// 	Throw <typeparamref name="TE"/> if <paramref name="domainResult"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// </summary>
+		/// <param name="domainResult"> The <see cref="System.ValueTuple{T,IDomainResult}"/> to check </param>
+		/// <param name="errMsg"> The error message </param>
+		/// <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
+		/// <typeparam name="TE">The exception type to throw if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </typeparam>
+		/// <typeparam name="T"> The value type of successful <paramref name="domainResult"/> </typeparam>
+		public static T ThrowIfNoSuccess<T, TE>(this (T result, IDomainResult status) domainResult, string? errMsg = null) where TE: Exception, new()
+		{
+			var (result, status) = domainResult;
+			if (status.IsSuccess)
+				return result;
+			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			catch (MissingMethodException) { throw new TE(); }
+		}
+		
+		/// <summary>
+		/// 	Throw <typeparamref name="TE"/> if <paramref name="domainResultTask"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// </summary>
+		/// <param name="domainResultTask"> The <see cref="System.Threading.Tasks.Task{IDomainResult}"/> to check </param>
+		/// <param name="errMsg"> The error message </param>
+		/// <exception cref="DomainResultException"> The thrown exception if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </exception>
+		/// <typeparam name="TE">The exception type to throw if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </typeparam>
+		public static async Task ThrowIfNoSuccess<TE>(this Task<IDomainResult> domainResultTask, string? errMsg = null) where TE: Exception, new()
+		{		
+			var domainResult = await domainResultTask.ConfigureAwait(true);
+			if (domainResult.IsSuccess)
+				return;
+			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			catch (MissingMethodException) { throw new TE(); }
+		}
+		/// <summary>
+		///		Throw <typeparamref name="TE"/> if <paramref name="domainResultTask"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// </summary>
+		/// <param name="domainResultTask"> The <see cref="System.Threading.Tasks.Task{IDomainResult}"/> to check </param>
+		/// <param name="errMsg"> The error message </param>
+		/// <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
+		/// <typeparam name="TE">The exception type to throw if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </typeparam>
+		/// <typeparam name="T"> The value type of successful <paramref name="domainResultTask"/> </typeparam>
+		public static async Task<T> ThrowIfNoSuccess<T,TE>(this Task<IDomainResult<T>> domainResultTask, string? errMsg = null) where TE: Exception, new()
+		{
+			var domainResult = await domainResultTask.ConfigureAwait(true);
+			if (domainResult.IsSuccess)
+				return domainResult.Value;
+			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			catch (MissingMethodException) { throw new TE(); }
+		}
+		/// <summary>
+		///		Throw <typeparamref name="TE"/> if <paramref name="domainResultTask"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// </summary>
+		/// <param name="domainResultTask"> The <see cref="System.Threading.Tasks.Task{IDomainResult}"/> to check </param>
+		/// <param name="errMsg"> The error message </param>
+		/// <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
+		/// <typeparam name="TE">The exception type to throw if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </typeparam>
+		/// <typeparam name="T"> The value type of successful <paramref name="domainResultTask"/> </typeparam>
+		public static async Task<T> ThrowIfNoSuccess<T,TE>(this Task<(T result, IDomainResult status)> domainResultTask, string? errMsg = null) where TE: Exception, new()
+		{
+			var (result, status) = await domainResultTask.ConfigureAwait(true);
+			if (status.IsSuccess)
+				return result;
+			try { throw (TE)Activator.CreateInstance(typeof(TE), errMsg); }
+			catch (MissingMethodException) { throw new TE(); }
+		}
+	}
+}

--- a/src/Common/Exceptions/DomainResultThrowExceptionExtensions.cs
+++ b/src/Common/Exceptions/DomainResultThrowExceptionExtensions.cs
@@ -23,17 +23,33 @@ namespace DomainResults.Common.Exceptions
 		/// </summary>
 		/// <param name="domainResult"> The IDomainResult to check </param>
 		/// <param name="errMsg"> The error message </param>
+		/// <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
 		/// <exception cref="DomainResultException"> The thrown exception if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </exception>
-		public static void ThrowIfNoSuccess<T>(this IDomainResult<T> domainResult, string? errMsg = null)
+		public static T ThrowIfNoSuccess<T>(this IDomainResult<T> domainResult, string? errMsg = null)
 		{
 			if (!domainResult.IsSuccess)
 				throw new DomainResultException(domainResult, errMsg);
+			return domainResult.Value;
+		}
+		/// <summary>
+		///		Throw <see cref="DomainResultException"/> if <paramref name="domainResult"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// </summary>
+		/// <param name="domainResult"> The <see cref="System.ValueTuple{T,IDomainResult}"/> to check </param>
+		/// <param name="errMsg"> The error message </param>
+		/// <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
+		/// <exception cref="DomainResultException"> The thrown exception if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </exception>
+		public static T ThrowIfNoSuccess<T>(this (T result, IDomainResult status) domainResult, string? errMsg = null)
+		{
+			var (result, status) = domainResult;
+			if (!status.IsSuccess)
+				throw new DomainResultException(status, errMsg);
+			return result;
 		}
 		
 		/// <summary>
 		///		Throw <see cref="DomainResultException"/> if <paramref name="domainResultTask"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
 		/// </summary>
-		/// <param name="domainResultTask"> The IDomainResult to check </param>
+		/// <param name="domainResultTask"> The <see cref="System.Threading.Tasks.Task{IDomainResult}"/> to check </param>
 		/// <param name="errMsg"> The error message </param>
 		/// <exception cref="DomainResultException"> The thrown exception if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </exception>
 		public static async Task ThrowIfNoSuccess(this Task<IDomainResult> domainResultTask, string? errMsg = null)
@@ -45,14 +61,30 @@ namespace DomainResults.Common.Exceptions
 		/// <summary>
 		///		Throw <see cref="DomainResultException"/> if <paramref name="domainResultTask"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
 		/// </summary>
-		/// <param name="domainResultTask"> The IDomainResult to check </param>
+		/// <param name="domainResultTask"> The <see cref="System.Threading.Tasks.Task{IDomainResult}"/> to check </param>
 		/// <param name="errMsg"> The error message </param>
+		/// <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
 		/// <exception cref="DomainResultException"> The thrown exception if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </exception>
-		public static async Task ThrowIfNoSuccess<T>(this Task<IDomainResult<T>> domainResultTask, string? errMsg = null)
+		public static async Task<T> ThrowIfNoSuccess<T>(this Task<IDomainResult<T>> domainResultTask, string? errMsg = null)
 		{
 			var domainResult = await domainResultTask.ConfigureAwait(true);
 			if (!domainResult.IsSuccess)
 				throw new DomainResultException(domainResult, errMsg);
+			return domainResult.Value;
+		}
+		/// <summary>
+		///		Throw <see cref="DomainResultException"/> if <paramref name="domainResultTask"/>'s <see cref="DomainResult.IsSuccess"/> is <value>false</value> 
+		/// </summary>
+		/// <param name="domainResultTask"> The <see cref="System.Threading.Tasks.Task{IDomainResult}"/> to check </param>
+		/// <param name="errMsg"> The error message </param>
+		/// <returns> The value, if the <see cref="DomainResult.IsSuccess"/> is <value>true</value> </returns>
+		/// <exception cref="DomainResultException"> The thrown exception if the <see cref="DomainResult.IsSuccess"/> is <value>false</value> </exception>
+		public static async Task<T> ThrowIfNoSuccess<T>(this Task<(T result, IDomainResult status)> domainResultTask, string? errMsg = null)
+		{
+			var (result, status) = await domainResultTask.ConfigureAwait(true);
+			if (!status.IsSuccess)
+				throw new DomainResultException(status, errMsg);
+			return result;
 		}
 	}
 }

--- a/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedCustom.cs
+++ b/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedCustom.cs
@@ -18,7 +18,7 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		var exc = Assert.Throws<CustomException>(
 			() => domainResult.ThrowIfNoSuccess<CustomException>("Error Message")
 			);
-		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal("Bla. Error Message", exc.Message);
 	}
 	[Fact]
 	public void Failed_DomainResultOfT_Throws_Custom_Exception_On_Check()
@@ -27,7 +27,7 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		var exc = Assert.Throws<CustomException>(
 			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
 			);
-		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal("Bla. Error Message", exc.Message);
 	}
 	[Fact]
 	public void Failed_IDomainResultOfT_Throws_Custom_Exception_On_Check()
@@ -36,7 +36,7 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		var exc = Assert.Throws<CustomException>(
 			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
 		);
-		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal("Bla. Error Message", exc.Message);
 	}
 	[Fact]
 	public async void Failed_DomainResult_Task_Throws_Custom_Exception_On_Check()
@@ -45,7 +45,7 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		var exc = await Assert.ThrowsAsync<CustomException>(
 			() => domainResult.ThrowIfNoSuccess<CustomException>("Error Message")
 		);
-		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal("Bla. Error Message", exc.Message);
 	}
 	[Fact]
 	public async void Failed_IDomainResult_Task_Throws_Custom_Exception_On_Check()
@@ -54,7 +54,7 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		var exc = await Assert.ThrowsAsync<CustomException>(
 			() => domainResult.ThrowIfNoSuccess<CustomException>("Error Message")
 		);
-		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal("Bla. Error Message", exc.Message);
 	}
 	[Fact]
 	public async void Failed_DomainResultOfT_Task_Throws_Custom_Exception_On_Check()
@@ -63,7 +63,7 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		var exc = await Assert.ThrowsAsync<CustomException>(
 			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
 			);
-		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal("Bla. Error Message", exc.Message);
 	}
 	[Fact]
 	public async void Failed_IDomainResultOfT_Task_Throws_Custom_Exception_On_Check()
@@ -72,12 +72,40 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		var exc = await Assert.ThrowsAsync<CustomException>(
 			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
 		);
-		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal("Bla. Error Message", exc.Message);
 	}
 	
+	[Fact]
+	public void Failed_IDomainResult_Throws_Custom_Exception_With_No_Msg_On_Check()
+	{
+		var domainResult = IDomainResult.Failed("Bla");
+		Assert.Throws<CustomNoMsgException>(
+			() => domainResult.ThrowIfNoSuccess<CustomNoMsgException>("Error Message")
+		);
+	}
+	[Fact]
+	public async void Failed_DomainResultOfT_Task_Throws_Custom_Exception_With_No_Msg_On_Check()
+	{
+		var domainResult = DomainResult.FailedTask<int>("Bla");
+		await Assert.ThrowsAsync<CustomNoMsgException>(
+			() => domainResult.ThrowIfNoSuccess<int,CustomNoMsgException>("Error Message")
+		);
+	}
+	[Fact]
+	public async void Failed_IDomainResultOfT_Task_Throws_Custom_Exception_With_No_Msg_On_Check()
+	{
+		var domainResult = IDomainResult.FailedTask<int>("Bla");
+		await Assert.ThrowsAsync<CustomNoMsgException>(
+			() => domainResult.ThrowIfNoSuccess<int,CustomNoMsgException>("Error Message")
+		);
+	}
+
 	private class CustomException : Exception
 	{
+		// ReSharper disable once UnusedMember.Local
 		public CustomException(string msg): base(msg){}
-		public CustomException(): base(){}
+		public CustomException() {}
 	}
+	
+	private class CustomNoMsgException : Exception;
 }

--- a/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedCustom.cs
+++ b/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedCustom.cs
@@ -84,6 +84,14 @@ public partial class DomainResult_Throw_Exception_Extensions_Tests
 		);
 	}
 	[Fact]
+	public void Failed_DomainResultOfT_Throws_Custom_Exception_With_No_Msg_On_Check()
+	{
+		var domainResult = DomainResult.Failed<int>("Bla");
+		Assert.Throws<CustomNoMsgException>(
+			() => domainResult.ThrowIfNoSuccess<int,CustomNoMsgException>("Error Message")
+		);
+	}
+	[Fact]
 	public async void Failed_DomainResultOfT_Task_Throws_Custom_Exception_With_No_Msg_On_Check()
 	{
 		var domainResult = DomainResult.FailedTask<int>("Bla");

--- a/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedCustom.cs
+++ b/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedCustom.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+
+using DomainResults.Common;
+using DomainResults.Common.Exceptions;
+
+using Xunit;
+
+namespace DomainResults.Tests.Common;
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public partial class DomainResult_Throw_Exception_Extensions_Tests
+{
+	[Fact]
+	public void Failed_IDomainResult_Throws_Custom_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.Failed("Bla");
+		var exc = Assert.Throws<CustomException>(
+			() => domainResult.ThrowIfNoSuccess<CustomException>("Error Message")
+			);
+		Assert.Equal("Error Message", exc.Message);
+	}
+	[Fact]
+	public void Failed_DomainResultOfT_Throws_Custom_Exception_On_Check()
+	{
+		var domainResult = DomainResult.Failed<int>("Bla");
+		var exc = Assert.Throws<CustomException>(
+			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
+			);
+		Assert.Equal("Error Message", exc.Message);
+	}
+	[Fact]
+	public void Failed_IDomainResultOfT_Throws_Custom_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.Failed<int>("Bla");
+		var exc = Assert.Throws<CustomException>(
+			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+	}
+	[Fact]
+	public async void Failed_DomainResult_Task_Throws_Custom_Exception_On_Check()
+	{
+		var domainResult = DomainResult.FailedTask("Bla");
+		var exc = await Assert.ThrowsAsync<CustomException>(
+			() => domainResult.ThrowIfNoSuccess<CustomException>("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+	}
+	[Fact]
+	public async void Failed_IDomainResult_Task_Throws_Custom_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.FailedTask("Bla");
+		var exc = await Assert.ThrowsAsync<CustomException>(
+			() => domainResult.ThrowIfNoSuccess<CustomException>("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+	}
+	[Fact]
+	public async void Failed_DomainResultOfT_Task_Throws_Custom_Exception_On_Check()
+	{
+		var domainResult = DomainResult.FailedTask<int>("Bla");
+		var exc = await Assert.ThrowsAsync<CustomException>(
+			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
+			);
+		Assert.Equal("Error Message", exc.Message);
+	}
+	[Fact]
+	public async void Failed_IDomainResultOfT_Task_Throws_Custom_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.FailedTask<int>("Bla");
+		var exc = await Assert.ThrowsAsync<CustomException>(
+			() => domainResult.ThrowIfNoSuccess<int,CustomException>("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+	}
+	
+	private class CustomException : Exception
+	{
+		public CustomException(string msg): base(msg){}
+		public CustomException(): base(){}
+	}
+}

--- a/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedDefault.cs
+++ b/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.FailedDefault.cs
@@ -1,0 +1,90 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+using DomainResults.Common;
+using DomainResults.Common.Exceptions;
+
+using Xunit;
+
+namespace DomainResults.Tests.Common;
+
+[SuppressMessage("ReSharper", "InconsistentNaming")]
+public partial class DomainResult_Throw_Exception_Extensions_Tests
+{
+	[Fact]
+	public void Failed_IDomainResult_Throws_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.Failed("Bla");
+		var exc = Assert.Throws<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+			);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public void Failed_DomainResultOfT_Throws_Exception_On_Check()
+	{
+		var domainResult = DomainResult.Failed<int>("Bla");
+		var exc = Assert.Throws<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+			);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public void Failed_IDomainResultOfT_Throws_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.Failed<int>("Bla");
+		var exc = Assert.Throws<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public async void Failed_DomainResult_Task_Throws_Exception_On_Check()
+	{
+		var domainResult = DomainResult.FailedTask("Bla");
+		var exc = await Assert.ThrowsAsync<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public async void Failed_IDomainResult_Task_Throws_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.FailedTask("Bla");
+		var exc = await Assert.ThrowsAsync<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public async void Failed_DomainResultOfT_Task_Throws_Exception_On_Check()
+	{
+		var domainResult = DomainResult.FailedTask<int>("Bla");
+		var exc = await Assert.ThrowsAsync<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+			);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public async void Failed_IDomainResultOfT_Task_Throws_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.FailedTask<int>("Bla");
+		var exc = await Assert.ThrowsAsync<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+}

--- a/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.cs
+++ b/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.cs
@@ -8,7 +8,7 @@ using Xunit;
 namespace DomainResults.Tests.Common;
 
 [SuppressMessage("ReSharper", "InconsistentNaming")]
-public class DomainResult_Throw_Exception_Extensions_Tests
+public partial class DomainResult_Throw_Exception_Extensions_Tests
 {
 	[Fact]
 	public void Successful_IDomainResult_Doesnt_Throw_Exception_On_Check()
@@ -59,83 +59,5 @@ public class DomainResult_Throw_Exception_Extensions_Tests
 		var value = await domainResult.ThrowIfNoSuccess();
 		// No exception thrown
 		Assert.Equal(10, value);
-	}
-	
-	[Fact]
-	public void Failed_IDomainResult_Throws_Exception_On_Check()
-	{
-		var domainResult = IDomainResult.Failed("Bla");
-		var exc = Assert.Throws<DomainResultException>(
-			() => domainResult.ThrowIfNoSuccess("Error Message")
-			);
-		Assert.Equal("Error Message", exc.Message);
-		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
-		Assert.Equal(["Bla"], exc.DomainResult.Errors);
-	}
-	[Fact]
-	public void Failed_DomainResultOfT_Throws_Exception_On_Check()
-	{
-		var domainResult = DomainResult.Failed<int>("Bla");
-		var exc = Assert.Throws<DomainResultException>(
-			() => domainResult.ThrowIfNoSuccess("Error Message")
-			);
-		Assert.Equal("Error Message", exc.Message);
-		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
-		Assert.Equal(["Bla"], exc.DomainResult.Errors);
-	}
-	[Fact]
-	public void Failed_IDomainResultOfT_Throws_Exception_On_Check()
-	{
-		var domainResult = IDomainResult.Failed<int>("Bla");
-		var exc = Assert.Throws<DomainResultException>(
-			() => domainResult.ThrowIfNoSuccess("Error Message")
-		);
-		Assert.Equal("Error Message", exc.Message);
-		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
-		Assert.Equal(["Bla"], exc.DomainResult.Errors);
-	}
-	[Fact]
-	public async void Failed_DomainResult_Task_Throws_Exception_On_Check()
-	{
-		var domainResult = DomainResult.FailedTask("Bla");
-		var exc = await Assert.ThrowsAsync<DomainResultException>(
-			() => domainResult.ThrowIfNoSuccess("Error Message")
-		);
-		Assert.Equal("Error Message", exc.Message);
-		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
-		Assert.Equal(["Bla"], exc.DomainResult.Errors);
-	}
-	[Fact]
-	public async void Failed_IDomainResult_Task_Throws_Exception_On_Check()
-	{
-		var domainResult = IDomainResult.FailedTask("Bla");
-		var exc = await Assert.ThrowsAsync<DomainResultException>(
-			() => domainResult.ThrowIfNoSuccess("Error Message")
-		);
-		Assert.Equal("Error Message", exc.Message);
-		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
-		Assert.Equal(["Bla"], exc.DomainResult.Errors);
-	}
-	[Fact]
-	public async void Failed_DomainResultOfT_Task_Throws_Exception_On_Check()
-	{
-		var domainResult = DomainResult.FailedTask<int>("Bla");
-		var exc = await Assert.ThrowsAsync<DomainResultException>(
-			() => domainResult.ThrowIfNoSuccess("Error Message")
-			);
-		Assert.Equal("Error Message", exc.Message);
-		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
-		Assert.Equal(["Bla"], exc.DomainResult.Errors);
-	}
-	[Fact]
-	public async void Failed_IDomainResultOfT_Task_Throws_Exception_On_Check()
-	{
-		var domainResult = IDomainResult.FailedTask<int>("Bla");
-		var exc = await Assert.ThrowsAsync<DomainResultException>(
-			() => domainResult.ThrowIfNoSuccess("Error Message")
-		);
-		Assert.Equal("Error Message", exc.Message);
-		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
-		Assert.Equal(["Bla"], exc.DomainResult.Errors);
 	}
 }

--- a/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.cs
+++ b/tests/DomainResults.Tests/Common/DomainResultThrowExceptionExtensionsTests.cs
@@ -13,40 +13,58 @@ public class DomainResult_Throw_Exception_Extensions_Tests
 	[Fact]
 	public void Successful_IDomainResult_Doesnt_Throw_Exception_On_Check()
 	{
-		var domainResult = DomainResult.Success();
+		var domainResult = IDomainResult.Success();
 		domainResult.ThrowIfNoSuccess();
 		// No exception thrown
 		Assert.True(domainResult.IsSuccess);
+	}
+	[Fact]
+	public void Successful_DomainResultOfT_Doesnt_Throw_Exception_On_Check()
+	{
+		var domainResult = DomainResult.Success(10);
+		var value = domainResult.ThrowIfNoSuccess();
+		
+		Assert.True(domainResult.IsSuccess);
+		Assert.Equal(10, value);
 	}
 	[Fact]
 	public void Successful_IDomainResultOfT_Doesnt_Throw_Exception_On_Check()
 	{
-		var domainResult = DomainResult.Success(10);
-		domainResult.ThrowIfNoSuccess();
-		// No exception thrown
-		Assert.True(domainResult.IsSuccess);
+		var domainResult = IDomainResult.Success(10);
+		var value = domainResult.ThrowIfNoSuccess();
+		
+		Assert.Equal(10, value);
 	}
 	[Fact]
 	public async void Successful_IDomainResult_Task_Doesnt_Throw_Exception_On_Check()
 	{
-		var domainResult = DomainResult.SuccessTask();
-		domainResult.ThrowIfNoSuccess();
-		// No exception thrown
+		var domainResult = IDomainResult.SuccessTask();
+		await domainResult.ThrowIfNoSuccess();
+		
 		Assert.True((await domainResult).IsSuccess);
+	}
+	[Fact]
+	public async void Successful_DomainResultOfT_Task_Doesnt_Throw_Exception_On_Check()
+	{
+		var domainResult = DomainResult.SuccessTask(10);
+		var value = await domainResult.ThrowIfNoSuccess();
+		
+		Assert.True((await domainResult).IsSuccess);
+		Assert.Equal(10, value);
 	}
 	[Fact]
 	public async void Successful_IDomainResultOfT_Task_Doesnt_Throw_Exception_On_Check()
 	{
-		var domainResult = DomainResult.SuccessTask(10);
-		domainResult.ThrowIfNoSuccess();
+		var domainResult = IDomainResult.SuccessTask(10);
+		var value = await domainResult.ThrowIfNoSuccess();
 		// No exception thrown
-		Assert.True((await domainResult).IsSuccess);
+		Assert.Equal(10, value);
 	}
 	
 	[Fact]
 	public void Failed_IDomainResult_Throws_Exception_On_Check()
 	{
-		var domainResult = DomainResult.Failed("Bla");
+		var domainResult = IDomainResult.Failed("Bla");
 		var exc = Assert.Throws<DomainResultException>(
 			() => domainResult.ThrowIfNoSuccess("Error Message")
 			);
@@ -55,7 +73,7 @@ public class DomainResult_Throw_Exception_Extensions_Tests
 		Assert.Equal(["Bla"], exc.DomainResult.Errors);
 	}
 	[Fact]
-	public void Failed_IDomainResultOfT_Throws_Exception_On_Check()
+	public void Failed_DomainResultOfT_Throws_Exception_On_Check()
 	{
 		var domainResult = DomainResult.Failed<int>("Bla");
 		var exc = Assert.Throws<DomainResultException>(
@@ -66,7 +84,18 @@ public class DomainResult_Throw_Exception_Extensions_Tests
 		Assert.Equal(["Bla"], exc.DomainResult.Errors);
 	}
 	[Fact]
-	public async void Failed_IDomainResult_Task_Throws_Exception_On_Check()
+	public void Failed_IDomainResultOfT_Throws_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.Failed<int>("Bla");
+		var exc = Assert.Throws<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public async void Failed_DomainResult_Task_Throws_Exception_On_Check()
 	{
 		var domainResult = DomainResult.FailedTask("Bla");
 		var exc = await Assert.ThrowsAsync<DomainResultException>(
@@ -77,12 +106,34 @@ public class DomainResult_Throw_Exception_Extensions_Tests
 		Assert.Equal(["Bla"], exc.DomainResult.Errors);
 	}
 	[Fact]
-	public async void Failed_IDomainResultOfT_Task_Throws_Exception_On_Check()
+	public async void Failed_IDomainResult_Task_Throws_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.FailedTask("Bla");
+		var exc = await Assert.ThrowsAsync<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+		);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public async void Failed_DomainResultOfT_Task_Throws_Exception_On_Check()
 	{
 		var domainResult = DomainResult.FailedTask<int>("Bla");
 		var exc = await Assert.ThrowsAsync<DomainResultException>(
 			() => domainResult.ThrowIfNoSuccess("Error Message")
 			);
+		Assert.Equal("Error Message", exc.Message);
+		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
+		Assert.Equal(["Bla"], exc.DomainResult.Errors);
+	}
+	[Fact]
+	public async void Failed_IDomainResultOfT_Task_Throws_Exception_On_Check()
+	{
+		var domainResult = IDomainResult.FailedTask<int>("Bla");
+		var exc = await Assert.ThrowsAsync<DomainResultException>(
+			() => domainResult.ThrowIfNoSuccess("Error Message")
+		);
 		Assert.Equal("Error Message", exc.Message);
 		Assert.Equal(DomainOperationStatus.Failed, exc.DomainResult.Status);
 		Assert.Equal(["Bla"], exc.DomainResult.Errors);

--- a/tests/DomainResults.Tests/DomainResults.Tests.csproj
+++ b/tests/DomainResults.Tests/DomainResults.Tests.csproj
@@ -26,7 +26,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Compile Update="**\DomainResultThrowExceptionExtensionsTests.*.cs" DependentUpon="DomainResultThrowExceptionExtensionsTests.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add extension methods for 
 - throwing exceptions for ValueTuples, e.g. `(T result, IDomainResult status).ThrowIfNoSuccess()`;
 - throwing custom exceptions, e.g. `status.ThrowIfNoSuccess<CustomException>()`.